### PR TITLE
add MAP_NONBLOCK

### DIFF
--- a/abuse-ramdisk/src/main.rs
+++ b/abuse-ramdisk/src/main.rs
@@ -196,6 +196,7 @@ fn main() {
                     let mut map_flags = MapFlags::empty();
                     map_flags.insert(MapFlags::MAP_SHARED);
                     map_flags.insert(MapFlags::MAP_POPULATE);
+                    map_flags.insert(MapFlags::MAP_NONBLOCK);
                     let p = unsafe { mmap(p0, map_len, prot_flags, map_flags, fd, page_address) }.expect("failed to mmap");
 
                     chunks.push(IoChunk {


### PR DESCRIPTION
This flag avoids read-ahead but just set the page table.
Since the page exists read-ahead is meaningless.