### PR TITLE
Use bio_vec multi-page

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Cat make.log
         run: |
+          sudo cat /var/lib/dkms/abuse/1.0.0/build/make.log
           sudo dmesg
           sudo cat abuse.log
-          sudo cat /var/lib/dkms/abuse/1.0.0/build/make.log
         if: ${{ failure() }}

--- a/abuse-kmod/src/abuse.c
+++ b/abuse-kmod/src/abuse.c
@@ -190,14 +190,16 @@ static int abuse_get_req(struct abuse_device *ab, struct abuse_xfr_hdr __user *a
 		xfr.ab_command = xfr_command_from_cmd_flags(req->rq->cmd_flags);
 		xfr.ab_offset = blk_rq_pos(req->rq) << SECTOR_SHIFT;
 		xfr.ab_len = blk_rq_bytes(req->rq);
-		rq_for_each_segment(bvec, req->rq, iter) {
+		rq_for_each_bvec(bvec, req->rq, iter) {
 			// physical address of the page
 			ab->ab_xfer[i].ab_address = (__u64)page_to_phys(bvec.bv_page);
+			ab->ab_xfer[i].n_pages = ((bvec.bv_offset + bvec.bv_len) + (4096-1)) / 4096;
 			ab->ab_xfer[i].ab_offset = bvec.bv_offset;
 			ab->ab_xfer[i].ab_len = bvec.bv_len;
-			++i;
+			i++;
 		}
 		xfr.ab_vec_count = i;
+		ab->xfer_count = i;
 	} else {
 		spin_unlock_irq(&ab->ab_lock);
 		return -ENOMSG;

--- a/abuse-kmod/src/abuse.c
+++ b/abuse-kmod/src/abuse.c
@@ -199,7 +199,7 @@ static int abuse_get_req(struct abuse_device *ab, struct abuse_xfr_hdr __user *a
 			i++;
 		}
 		xfr.ab_vec_count = i;
-		ab->xfer_count = i;
+		ab->ab_xfer_count = i;
 	} else {
 		spin_unlock_irq(&ab->ab_lock);
 		return -ENOMSG;

--- a/abuse-kmod/src/abuse.h
+++ b/abuse-kmod/src/abuse.h
@@ -40,6 +40,7 @@ struct abuse_info {
 
 struct abuse_vec {
 	__u64 ab_address;
+	__u32 n_pages;
 	__u32 ab_offset;
 	__u32 ab_len;
 };
@@ -89,6 +90,7 @@ struct abuse_device {
 	struct gendisk *ab_disk;
 
 	/* user xfer area */
+	int ab_xfer_count;
 	struct abuse_vec ab_xfer[BIO_MAX_VECS];
 };
 

--- a/abuse-ramdisk/src/main.rs
+++ b/abuse-ramdisk/src/main.rs
@@ -64,25 +64,27 @@ impl MemBuffer {
         Self { buf: vec![0; n] }
     }
     fn write(&mut self, offset: usize, io_vecs: &[IOVec]) {
-        let mut offset = offset;
-        let dst = self.buf[offset..].as_ptr();
-        let dst = unsafe { std::mem::transmute::<*const u8, *mut c_void>(dst) };
+        let mut cur = offset;
 
         for io_vec in io_vecs {
-            let n = io_vec.len();
-            unsafe { io_vec.start().copy_to_nonoverlapping(dst, n) };
-            offset += n;
+            let dst = self.buf[cur..].as_ptr();
+            let dst = unsafe { std::mem::transmute::<*const u8, *mut c_void>(dst) };
+
+            let len = io_vec.len();
+            unsafe { io_vec.start().copy_to_nonoverlapping(dst, len) };
+            cur += len;
         }
     }
     fn read(&self, offset: usize, io_vecs: &[IOVec]) {
-        let mut offset = offset;
-        let src = self.buf[offset..].as_ptr();
-        let src = unsafe { std::mem::transmute::<*const u8, *mut c_void>(src) };
+        let mut cur = offset;
 
         for io_vec in io_vecs {
-            let n = io_vec.len();
-            unsafe { io_vec.start().copy_from_nonoverlapping(src, n) };
-            offset += n;
+            let src = self.buf[cur..].as_ptr();
+            let src = unsafe { std::mem::transmute::<*const u8, *mut c_void>(src) };
+
+            let len = io_vec.len();
+            unsafe { io_vec.start().copy_from_nonoverlapping(src, len) };
+            cur += len;
         }
     }
 }


### PR DESCRIPTION
Back in 2019, bvec is allowed to have multiple pages. Apparently, it is more efficient to use this feature.

https://patchwork.kernel.org/project/linux-fsdevel/cover/20190111110127.21664-1-ming.lei@redhat.com/